### PR TITLE
Use "fewer than" for discrete countable things.

### DIFF
--- a/packages/snap/src/insights.ts
+++ b/packages/snap/src/insights.ts
@@ -109,7 +109,7 @@ export async function getContractInteractionScore({
 
   return {
     score: 1,
-    description: 'less than 2 txs',
+    description: 'fewer than 2 txs',
   };
 }
 
@@ -160,7 +160,7 @@ export async function getContractTransactionCountScore({
 
   return {
     score: 1,
-    description: 'less than 49 txs',
+    description: 'fewer than 49 txs',
   };
 }
 


### PR DESCRIPTION
For countable things, such as transactions, use "fewer than" not "less than".

https://www.merriam-webster.com/words-at-play/fewer-vs-less